### PR TITLE
convert to a four-stage build to move common commands to base

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.dockerignore
+.git
+env*
+*.sqlite3
+webapp/combined.js

--- a/install.sh
+++ b/install.sh
@@ -2,12 +2,15 @@
 
 set -e
 
-rm -f scilab.sqlite3
+python3 -m venv env
+. env/bin/activate
+pip install -q -U pip setuptools wheel
+pip install -q -r ${BRANCH}/requirements.txt
+
 sqlite3 scilab.sqlite3 < resources/scilab_tbc.sql
 
 sed -i \
     -e "s/\\(SCILAB_DIR = \\).*/\\1'\/usr\/local'/" \
     config.py
 
-rm -f webapp/combined.js
 make

--- a/installenv.sh
+++ b/installenv.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -e
-
-rm -rf env
-python3 -m venv env
-. env/bin/activate
-pip install -q -U pip setuptools wheel
-pip install -q -r ${BRANCH}/requirements.txt

--- a/master-2023.1/Dockerfile
+++ b/master-2023.1/Dockerfile
@@ -1,30 +1,33 @@
-FROM ubuntu:22.04 AS build-scilab
+FROM ubuntu:22.04 AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV UBUNTU_FRONTEND=noninteractive
 
-ARG HOME=/root
+ENV HOME=/root
 
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
 
 # Add sources and Install pre-requisites
 RUN sed -i 's/^# *\(deb-src .*\.ubuntu\.com\)/\1/' /etc/apt/sources.list
-RUN apt-get update -qq
-RUN apt-get upgrade -qq
-RUN apt-get install -qq apt-utils
-RUN apt-get install -qq build-essential iproute2 libgfortran5 \
-  openjdk-8-jre python3 sqlite3 tzdata
+RUN apt-get update -qq && \
+  apt-get upgrade -qq && \
+  apt-get install -qq apt-utils && \
+  apt-get install -qq build-essential iproute2 libgfortran5 openjdk-8-jre python3 sqlite3 tzdata
 
 # Set timezone info
 RUN ln -fs /usr/share/zoneinfo/Asia/Kolkata /etc/localtime
 RUN dpkg-reconfigure -f noninteractive tzdata
 
+
+FROM base AS build-scilab
+
 # packages to be removed later
-RUN apt-get install -qq devscripts equivs git openjdk-8-jdk
-WORKDIR ${HOME}
-RUN mk-build-deps scilab
-RUN apt-get install -qq ./scilab-build-deps_*.deb
+RUN apt-get update -qq && \
+  apt-get install -qq devscripts equivs git openjdk-8-jdk && \
+  mk-build-deps scilab && \
+  apt-get install -qq ./scilab-build-deps_*.deb && \
+  rm -f ./scilab-build-deps_*.deb
 
 # Build scilab
 ARG BRANCH=master-2023.1
@@ -37,10 +40,7 @@ RUN make -j4 -s || make
 RUN make -s install-strip
 
 # Cleanup
-WORKDIR ${HOME}
-RUN apt-get autoremove -qq --purge bsdmainutils devscripts equivs git \
-  openjdk-8-jdk openjdk-11-jre-headless scilab-build-deps
-RUN rm -f ./scilab-build-deps_*.deb
+RUN apt-get autoremove -qq --purge bsdmainutils devscripts equivs git openjdk-8-jdk openjdk-11-jre-headless scilab-build-deps
 
 # Copy missing libs
 WORKDIR ${SCILAB_DIR}
@@ -72,42 +72,20 @@ RUN find /usr/local -depth -type d -name tests -print0 | xargs -0 rm -rf
 #RUN dpkg-query -Wf '${Installed-Size}\t${Package}\t${Version}\n' > /tmp/dpkg-scilab
 #RUN find / -mount \( -path /tmp -o -path /var/lib/ucf \) -prune -o ! -type d -print | sort > /tmp/filelist-scilab
 
-FROM ubuntu:22.04 AS build-xcos
 
-ENV DEBIAN_FRONTEND=noninteractive
-ENV UBUNTU_FRONTEND=noninteractive
-
-ARG HOME=/root
-
-ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
-
-# Add sources and Install pre-requisites
-RUN sed -i 's/^# *\(deb-src .*\.ubuntu\.com\)/\1/' /etc/apt/sources.list
-RUN apt-get update -qq
-RUN apt-get upgrade -qq
-RUN apt-get install -qq apt-utils
-RUN apt-get install -qq build-essential iproute2 libgfortran5 \
-  openjdk-8-jre python3 sqlite3 tzdata
-
-# Set timezone info
-RUN ln -fs /usr/share/zoneinfo/Asia/Kolkata /etc/localtime
-RUN dpkg-reconfigure -f noninteractive tzdata
+FROM base AS build-xcos
 
 # packages to be removed later
-RUN apt-get install -qq python3-pip python3-venv
+RUN apt-get update -qq && \
+  apt-get install -qq python3-pip python3-venv
 
 # Build XCos
 ARG BRANCH=master-2023.1
 ARG XCOS_DIR=${HOME}/xcos_on_cloud
 WORKDIR ${XCOS_DIR}
 COPY . .
-RUN rm -rf .git*
 
-# Configure venv
-RUN bash ./installenv.sh
-
-# Configure sqlite3
+# Configure venv and sqlite3
 RUN bash ./install.sh
 
 # Cleanup
@@ -118,29 +96,10 @@ RUN rm -rf ${HOME}/.cache
 #RUN dpkg-query -Wf '${Installed-Size}\t${Package}\t${Version}\n' > /tmp/dpkg-xcos
 #RUN find / -mount \( -path /tmp -o -path /var/lib/ucf \) -prune -o ! -type d -print | sort > /tmp/filelist-xcos
 
-FROM ubuntu:22.04 AS main
+
+FROM base AS main
 
 EXPOSE 8001
-
-ENV DEBIAN_FRONTEND=noninteractive
-ENV UBUNTU_FRONTEND=noninteractive
-
-ARG HOME=/root
-
-ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
-
-# Add sources and Install pre-requisites
-RUN sed -i 's/^# *\(deb-src .*\.ubuntu\.com\)/\1/' /etc/apt/sources.list
-RUN apt-get update -qq
-RUN apt-get upgrade -qq
-RUN apt-get install -qq apt-utils
-RUN apt-get install -qq build-essential iproute2 libgfortran5 \
-  openjdk-8-jre python3 sqlite3 tzdata
-
-# Set timezone info
-RUN ln -fs /usr/share/zoneinfo/Asia/Kolkata /etc/localtime
-RUN dpkg-reconfigure -f noninteractive tzdata
 
 # Install scilab
 ARG SCILAB_DIR=${HOME}/scilab_for_xcos_on_cloud

--- a/master-5.5/Dockerfile
+++ b/master-5.5/Dockerfile
@@ -1,30 +1,33 @@
-FROM ubuntu:18.04 AS build-scilab
+FROM ubuntu:18.04 AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV UBUNTU_FRONTEND=noninteractive
 
-ARG HOME=/root
+ENV HOME=/root
 
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
 
 # Add sources and Install pre-requisites
 RUN sed -i 's/^# *\(deb-src .*\.ubuntu\.com\)/\1/' /etc/apt/sources.list
-RUN apt-get update -qq
-RUN apt-get upgrade -qq
-RUN apt-get install -qq apt-utils
-RUN apt-get install -qq build-essential iproute2 libgfortran3 libgfortran4 \
-  openjdk-8-jre python3 sqlite3 tzdata
+RUN apt-get update -qq && \
+  apt-get upgrade -qq && \
+  apt-get install -qq apt-utils && \
+  apt-get install -qq build-essential iproute2 libgfortran3 libgfortran4 openjdk-8-jre python3 sqlite3 tzdata
 
 # Set timezone info
 RUN ln -fs /usr/share/zoneinfo/Asia/Kolkata /etc/localtime
 RUN dpkg-reconfigure -f noninteractive tzdata
 
+
+FROM base AS build-scilab
+
 # packages to be removed later
-RUN apt-get install -qq devscripts equivs git openjdk-8-jdk
-WORKDIR ${HOME}
-RUN mk-build-deps scilab
-RUN apt-get install -qq ./scilab-build-deps_*.deb
+RUN apt-get update -qq && \
+  apt-get install -qq devscripts equivs git openjdk-8-jdk && \
+  mk-build-deps scilab && \
+  apt-get install -qq ./scilab-build-deps_*.deb && \
+  rm -f ./scilab-build-deps_*.deb
 
 # Build scilab
 ARG BRANCH=master-5.5
@@ -37,10 +40,7 @@ RUN make -j4 -s || make
 RUN make -s install-strip
 
 # Cleanup
-WORKDIR ${HOME}
-RUN apt-get autoremove -qq --purge bsdmainutils devscripts equivs git \
-  openjdk-8-jdk openjdk-11-jre-headless scilab-build-deps
-RUN rm -f ./scilab-build-deps_*.deb
+RUN apt-get autoremove -qq --purge bsdmainutils devscripts equivs git openjdk-8-jdk openjdk-11-jre-headless scilab-build-deps
 
 # Copy missing libs
 WORKDIR ${SCILAB_DIR}
@@ -72,42 +72,20 @@ RUN find /usr/local -depth -type d -name tests -print0 | xargs -0 rm -rf
 #RUN dpkg-query -Wf '${Installed-Size}\t${Package}\t${Version}\n' > /tmp/dpkg-scilab
 #RUN find / -mount \( -path /tmp -o -path /var/lib/ucf \) -prune -o ! -type d -print | sort > /tmp/filelist-scilab
 
-FROM ubuntu:18.04 AS build-xcos
 
-ENV DEBIAN_FRONTEND=noninteractive
-ENV UBUNTU_FRONTEND=noninteractive
-
-ARG HOME=/root
-
-ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
-
-# Add sources and Install pre-requisites
-RUN sed -i 's/^# *\(deb-src .*\.ubuntu\.com\)/\1/' /etc/apt/sources.list
-RUN apt-get update -qq
-RUN apt-get upgrade -qq
-RUN apt-get install -qq apt-utils
-RUN apt-get install -qq build-essential iproute2 libgfortran3 libgfortran4 \
-  openjdk-8-jre python3 sqlite3 tzdata
-
-# Set timezone info
-RUN ln -fs /usr/share/zoneinfo/Asia/Kolkata /etc/localtime
-RUN dpkg-reconfigure -f noninteractive tzdata
+FROM base AS build-xcos
 
 # packages to be removed later
-RUN apt-get install -qq python3-pip python3-venv
+RUN apt-get update -qq && \
+  apt-get install -qq python3-pip python3-venv
 
 # Build XCos
 ARG BRANCH=master-5.5
 ARG XCOS_DIR=${HOME}/xcos_on_cloud
 WORKDIR ${XCOS_DIR}
 COPY . .
-RUN rm -rf .git*
 
-# Configure venv
-RUN bash ./installenv.sh
-
-# Configure sqlite3
+# Configure venv and sqlite3
 RUN bash ./install.sh
 
 # Cleanup
@@ -118,29 +96,10 @@ RUN rm -rf ${HOME}/.cache
 #RUN dpkg-query -Wf '${Installed-Size}\t${Package}\t${Version}\n' > /tmp/dpkg-xcos
 #RUN find / -mount \( -path /tmp -o -path /var/lib/ucf \) -prune -o ! -type d -print | sort > /tmp/filelist-xcos
 
-FROM ubuntu:18.04 AS main
+
+FROM base AS main
 
 EXPOSE 8001
-
-ENV DEBIAN_FRONTEND=noninteractive
-ENV UBUNTU_FRONTEND=noninteractive
-
-ARG HOME=/root
-
-ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
-
-# Add sources and Install pre-requisites
-RUN sed -i 's/^# *\(deb-src .*\.ubuntu\.com\)/\1/' /etc/apt/sources.list
-RUN apt-get update -qq
-RUN apt-get upgrade -qq
-RUN apt-get install -qq apt-utils
-RUN apt-get install -qq build-essential iproute2 libgfortran3 libgfortran4 \
-  openjdk-8-jre python3 sqlite3 tzdata
-
-# Set timezone info
-RUN ln -fs /usr/share/zoneinfo/Asia/Kolkata /etc/localtime
-RUN dpkg-reconfigure -f noninteractive tzdata
 
 # Install scilab
 ARG SCILAB_DIR=${HOME}/scilab_for_xcos_on_cloud

--- a/master-6.1/Dockerfile
+++ b/master-6.1/Dockerfile
@@ -1,30 +1,33 @@
-FROM ubuntu:22.04 AS build-scilab
+FROM ubuntu:22.04 AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV UBUNTU_FRONTEND=noninteractive
 
-ARG HOME=/root
+ENV HOME=/root
 
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
 
 # Add sources and Install pre-requisites
 RUN sed -i 's/^# *\(deb-src .*\.ubuntu\.com\)/\1/' /etc/apt/sources.list
-RUN apt-get update -qq
-RUN apt-get upgrade -qq
-RUN apt-get install -qq apt-utils
-RUN apt-get install -qq build-essential iproute2 libgfortran5 \
-  openjdk-8-jre python3 sqlite3 tzdata
+RUN apt-get update -qq && \
+  apt-get upgrade -qq && \
+  apt-get install -qq apt-utils && \
+  apt-get install -qq build-essential iproute2 libgfortran5 openjdk-8-jre python3 sqlite3 tzdata
 
 # Set timezone info
 RUN ln -fs /usr/share/zoneinfo/Asia/Kolkata /etc/localtime
 RUN dpkg-reconfigure -f noninteractive tzdata
 
+
+FROM base AS build-scilab
+
 # packages to be removed later
-RUN apt-get install -qq devscripts equivs git openjdk-8-jdk
-WORKDIR ${HOME}
-RUN mk-build-deps scilab
-RUN apt-get install -qq ./scilab-build-deps_*.deb
+RUN apt-get update -qq && \
+  apt-get install -qq devscripts equivs git openjdk-8-jdk && \
+  mk-build-deps scilab && \
+  apt-get install -qq ./scilab-build-deps_*.deb && \
+  rm -f ./scilab-build-deps_*.deb
 
 # Build scilab
 ARG BRANCH=master-6.1
@@ -37,10 +40,7 @@ RUN make -j4 -s || make
 RUN make -s install-strip
 
 # Cleanup
-WORKDIR ${HOME}
-RUN apt-get autoremove -qq --purge bsdmainutils devscripts equivs git \
-  openjdk-8-jdk openjdk-11-jre-headless scilab-build-deps
-RUN rm -f ./scilab-build-deps_*.deb
+RUN apt-get autoremove -qq --purge bsdmainutils devscripts equivs git openjdk-8-jdk openjdk-11-jre-headless scilab-build-deps
 
 # Copy missing libs
 WORKDIR ${SCILAB_DIR}
@@ -72,42 +72,20 @@ RUN find /usr/local -depth -type d -name tests -print0 | xargs -0 rm -rf
 #RUN dpkg-query -Wf '${Installed-Size}\t${Package}\t${Version}\n' > /tmp/dpkg-scilab
 #RUN find / -mount \( -path /tmp -o -path /var/lib/ucf \) -prune -o ! -type d -print | sort > /tmp/filelist-scilab
 
-FROM ubuntu:22.04 AS build-xcos
 
-ENV DEBIAN_FRONTEND=noninteractive
-ENV UBUNTU_FRONTEND=noninteractive
-
-ARG HOME=/root
-
-ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
-
-# Add sources and Install pre-requisites
-RUN sed -i 's/^# *\(deb-src .*\.ubuntu\.com\)/\1/' /etc/apt/sources.list
-RUN apt-get update -qq
-RUN apt-get upgrade -qq
-RUN apt-get install -qq apt-utils
-RUN apt-get install -qq build-essential iproute2 libgfortran5 \
-  openjdk-8-jre python3 sqlite3 tzdata
-
-# Set timezone info
-RUN ln -fs /usr/share/zoneinfo/Asia/Kolkata /etc/localtime
-RUN dpkg-reconfigure -f noninteractive tzdata
+FROM base AS build-xcos
 
 # packages to be removed later
-RUN apt-get install -qq python3-pip python3-venv
+RUN apt-get update -qq && \
+  apt-get install -qq python3-pip python3-venv
 
 # Build XCos
 ARG BRANCH=master-6.1
 ARG XCOS_DIR=${HOME}/xcos_on_cloud
 WORKDIR ${XCOS_DIR}
 COPY . .
-RUN rm -rf .git*
 
-# Configure venv
-RUN bash ./installenv.sh
-
-# Configure sqlite3
+# Configure venv and sqlite3
 RUN bash ./install.sh
 
 # Cleanup
@@ -118,29 +96,10 @@ RUN rm -rf ${HOME}/.cache
 #RUN dpkg-query -Wf '${Installed-Size}\t${Package}\t${Version}\n' > /tmp/dpkg-xcos
 #RUN find / -mount \( -path /tmp -o -path /var/lib/ucf \) -prune -o ! -type d -print | sort > /tmp/filelist-xcos
 
-FROM ubuntu:22.04 AS main
+
+FROM base AS main
 
 EXPOSE 8001
-
-ENV DEBIAN_FRONTEND=noninteractive
-ENV UBUNTU_FRONTEND=noninteractive
-
-ARG HOME=/root
-
-ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
-
-# Add sources and Install pre-requisites
-RUN sed -i 's/^# *\(deb-src .*\.ubuntu\.com\)/\1/' /etc/apt/sources.list
-RUN apt-get update -qq
-RUN apt-get upgrade -qq
-RUN apt-get install -qq apt-utils
-RUN apt-get install -qq build-essential iproute2 libgfortran5 \
-  openjdk-8-jre python3 sqlite3 tzdata
-
-# Set timezone info
-RUN ln -fs /usr/share/zoneinfo/Asia/Kolkata /etc/localtime
-RUN dpkg-reconfigure -f noninteractive tzdata
 
 # Install scilab
 ARG SCILAB_DIR=${HOME}/scilab_for_xcos_on_cloud


### PR DESCRIPTION
run apt-get update multiple times

combine apt-get update with other apt-get commands (install / upgrade / build-dep) to cache everything once

merge installenv.sh into install.sh

add a .dockerignore file