### PR TITLE
Potential fix for code scanning alert no. 18: Information exposure through an exception

### DIFF
--- a/SendLog.py
+++ b/SendLog.py
@@ -2170,7 +2170,8 @@ def example_page():
                                example_file=example_file,
                                example_file_id=example_file_id)
     except Exception as e:
-        return str(e)
+        logger.error('Error in example_page: %s', str(e))
+        return "An internal error has occurred!"
 
 
 @app.route('/ex')
@@ -2197,7 +2198,8 @@ def ajax_get_book():
         book = db_query(config.QUERY_BOOK, [category_id])
         return jsonify(book)
     except Exception as e:
-        return str(e)
+        logger.error('Error in ajax_get_book: %s', str(e))
+        return "An internal error has occurred!"
 
 
 @app.route('/get_chapter', methods=['GET', 'POST'])


### PR DESCRIPTION
Potential fix for [https://github.com/FOSSEE/xcos_on_cloud/security/code-scanning/18](https://github.com/FOSSEE/xcos_on_cloud/security/code-scanning/18)

To fix the problem, we should avoid returning the exception details directly to the user. Instead, we should log the exception details on the server and return a generic error message to the user. This approach ensures that sensitive information is not exposed while still allowing developers to access the necessary details for debugging.

1. Modify the exception handling block to log the exception details using the existing `logger` and return a generic error message to the user.
2. Ensure that the `logger` is properly configured to capture and store the exception details.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
